### PR TITLE
修复导航栏下移的问题

### DIFF
--- a/Stylish.Stylus.css
+++ b/Stylish.Stylus.css
@@ -37,6 +37,7 @@
     .WB_global_nav .gn_position {
         position: absolute !important;
         left: 0 !important;
+        top: 0;
     }
     .WB_global_nav .gn_position .gn_nav {
         margin: 12px 0 0 !important;
@@ -96,6 +97,7 @@
         margin: 11px 10px 0 0 !important;
         border: 0px !important;
         border-radius: 50px !important;
+        top: 0;
     }
     .WB_global_nav .gn_search_v2 .placeholder,
     .WB_global_nav .gn_search_v2 .W_input {


### PR DESCRIPTION
导航栏下拉菜单弹出时导航栏的内容会下移，移出导航栏的黑色背景。在.WB_global_nav .gn_search_v2和.WB_global_nav .gn_position 分别添加top： 0 可以解决。

![5d7d962f-331a-496e-a08b-978c2abda12b.jpg](https://storage.live.com/items/28C1032A24A9C53B!7544?authkey=AHAx3GOYEKGqm8I)
上图：在修改前

![36e3998d-e2aa-4312-a638-500c51a88067.jpg](https://storage.live.com/items/28C1032A24A9C53B!7545?authkey=AHAx3GOYEKGqm8I)
上图：修改后