### PR TITLE
Fix navigate bar

### DIFF
--- a/Stylish.Stylus.css
+++ b/Stylish.Stylus.css
@@ -22,7 +22,6 @@
     .WB_global_nav .gn_logo,
     .WB_global_nav .gn_logo .box,
     .WB_global_nav .gn_logo .box .logo {
-        width: 190px !important;
         margin: 0 !important;
         background-position: 0 50% !important;
     }


### PR DESCRIPTION
顶栏会向下悬空的原因似乎是搜索框的原因，修改了搜索框的对齐方式，在本地尝试已经不再有图标悬空的问题了。

另外，调整了左上角微博图标的尺寸和顶栏图标位置，使微博图标正常显示，避免图标变形。

本人技术仅是入门，只是凭自己感觉微调一下。